### PR TITLE
Promote to prod environment

### DIFF
--- a/components/python-hxnhvtzz/overlays/prod/deployment-patch.yaml
+++ b/components/python-hxnhvtzz/overlays/prod/deployment-patch.yaml
@@ -12,5 +12,5 @@ spec:
   template: 
     spec:
       containers:
-      - image: quay.io/redhat-tssc/task-runner:1.7
+      - image: artifactory-docker-artifactory-jcr2.apps.rosa.rhtap-services.xmdt.p3.openshiftapps.com/rhtap/python-hxnhvtzz:github-0964e4a747ca1c5e41b0be42ec44186014193fdb
         name: container-image  


### PR DESCRIPTION
This PR promotes the application to the prod environment with image: artifactory-docker-artifactory-jcr2.apps.rosa.rhtap-services.xmdt.p3.openshiftapps.com/rhtap/python-hxnhvtzz:github-0964e4a747ca1c5e41b0be42ec44186014193fdb